### PR TITLE
Respect user's locale

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,6 @@ __authors__ = 'Tilemachos Charalampous'
 __py_deps__ = ['requests', 'requests', 'pint', 'simpleeval', 'parsedatetime']
 
 
-import locale  # noqa: E402
 import os  # noqa: E402
 import sys  # noqa: E402
 
@@ -62,7 +61,6 @@ from calculate_anything.query.handlers import (  # noqa: E402
 from calculate_anything.utils import images_dir  # noqa: E402
 from albert import ClipAction, Item, debug, info, warning, critical  # type: ignore # noqa: E402, E501
 
-locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 # Thanks albert for making me hack the shit out of logging
 handler = logging.CustomHandler(debug, info, warning, critical, critical)

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,9 +53,6 @@ Example
 import locale
 from calculate_anything.preferences import Preferences
 
-# Set your locale
-locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
-
 preferences = Preferences()
 # Set the language
 preferences.language.set('en_US')

--- a/main.py
+++ b/main.py
@@ -33,9 +33,7 @@ from calculate_anything.query.handlers import MultiHandler
 from calculate_anything.time import TimezoneService
 from calculate_anything.lang import LanguageService
 from calculate_anything.currency import CurrencyService
-import locale
 
-locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 # See what I did for Ulauncher.
 # You won't let use my own formatter, due to duplicate logs

--- a/misc/prompt.py
+++ b/misc/prompt.py
@@ -25,9 +25,6 @@ from prompt_toolkit.validation import Validator
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit import HTML, PromptSession
 from prompt_toolkit.styles import Style
-import locale
-
-locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 
 # Setup Calculate Anything (Order is important)


### PR DESCRIPTION
Remove `locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')` from `main.py`, `__init__.py` and `prompt.py`
- Fixes #25