### PR TITLE
Fix fixerio not working with http:// uri.

### DIFF
--- a/calculate_anything/currency/providers/base.py
+++ b/calculate_anything/currency/providers/base.py
@@ -45,7 +45,9 @@ class CurrencyProvider(ABC):
         self.had_error = False
 
     @classmethod
-    def get_request(cls, params: Dict[str, str] = {}) -> Request:
+    def get_request(
+        cls, params: Dict[str, str] = {}, validate_uri: bool = True
+    ) -> Request:
         headers = {'user-agent': 'Calculate Anything'}
         url = urljoin(cls.BASE_URL, cls.API_URL)
         url = list(urlparse(url))
@@ -56,7 +58,7 @@ class CurrencyProvider(ABC):
         # Don't fucking install untrusted certs unless you want
         # a mitm xml bomb on your head
         # and no I won't install extra dependencies for your stupidity
-        if not re.match(r'^https:\/\/', request.full_url):
+        if validate_uri and not re.match(r'^https:\/\/', request.full_url):
             raise Exception('Invalid request url: {}'.format(request.full_url))
         return request
 

--- a/calculate_anything/currency/providers/fixerio.py
+++ b/calculate_anything/currency/providers/fixerio.py
@@ -92,7 +92,7 @@ class FixerIOCurrencyProvider(ApiKeyCurrencyProvider):
         if currencies:
             params['symbols'] = ','.join(currencies)
         try:
-            request = self.get_request(params)
+            request = self.get_request(params, validate_uri=False)
             logger.info('Making request to: {}'.format(request.full_url))
             with urlopen(request) as response:  # nosec
                 data = response.read().decode()

--- a/requirements/linting-requirements.txt
+++ b/requirements/linting-requirements.txt
@@ -1,3 +1,3 @@
 flake8==3.9.2
 pyproject-flake8==0.0.1a2
-black==21.7b0
+black==22.3.0


### PR DESCRIPTION
Fixerio was errored out because uri starts with http://, add parameter to get_requirest classmethod to allow for bypassing url check.
Update black dependency.