### PR TITLE
Ulauncher v6 compatibility, deadlock fix, and calculator features

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you are using Ulauncher use the extension preferences.
 
 The calculator supports calculating trig functions in degrees, radians (default), and gradians. Choose your preferred mode in the extension preferences.
 
-**Note**: Only the radian mode supports complex numbers.
+**Note**: Only the radian mode supports complex numbers in trig functions.
 
 ### Set Currency Provider
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ The extension can work in albert without keywords if you comment out the `__trig
 
 If you are using Ulauncher use the extension preferences.
 
+### Trigonometry Mode
+
+The calculator supports calculating trig functions in degrees, radians (default), and gradians. Choose your preferred mode in the extension preferences.
+
+**Note**: Only the radian mode supports complex numbers.
+
 ### Set Currency Provider
 
 You can select from different currency providers. Supported providers are:
@@ -333,6 +339,10 @@ The following constants exist: `pi`, `e`, `tau` and others from [cmath](https://
 
 The following functions exist: `phase`, `polar`, `rect`, `exp`, `log`, `log10`, `sqrt`, `acos`, `asin`, `atan`, `cos`, `sin`, `tan`, `acosh`, `asinh`, `atanh`, `cosh`, `sinh`, `tanh` and others from [cmath](https://docs.python.org/3/library/cmath.html)
 
+The functions `csc`, `sec`, `cot`, `acsc`, `asec`, and `acot` exist and are calculated using their reciprocals. `atan2` exists but supports only real numbers.
+
+`deg` and `rad` convert from radians to degrees and vice versa respectively, except in gradian mode where they convert from gradians to degrees and from gradians to radians respectively.
+
 #### **Simple Cases**
 - `10 + sqrt(2)`: Answer is 11.4142
 - `10 + cos(pi) + 30 * e ^ 2`: Answer is 230.672
@@ -342,6 +352,26 @@ Use i as the imaginary unit
 - `10 + sqrt(2) + i`: Answer is 11.4142 + i
 - `cos(1 + i)`: Answer is 0.83373 - 0.988898i
 - `e ^ (pi * i) + 1`: Answer is 0 (Euler's identity)
+
+#### **Memory**
+
+The `ans()` function returns the last calculated result.
+
+The calculator has 10 memory slots from `m0` to `m9` which can store numbers for later use. Their values are initialized to `0`, and they are persistent as long as the launcher is running. Reset the entire memory to `0` with `mc()`.
+
+Use the variables `m0` to `m9` to access memory slot values. Use the following functions to load and change the values (Replace `0` with a number from `0` to `9` to use the other slots):
+- `m0l(number)`: Load `m0` with `number`
+- `m0c()`: Clear `m0` (set to `0`)
+- `m0a(number)`: Add `number` to `m0`
+- `m0s(number)`: Subtract `number` from `m0`
+- `m0m(number)`: Multiply `m0` by `number`
+- `m0d(number)`: Divide `m0` by `number`
+- `m0e(number)`: Raise `m0` to the power of `number`
+- `m0r(number)`: Take the `number`th root of `m0`
+
+The functions return the new memory slot value after the operation to facilitate chaining.
+
+**Note**: the functions run every time a valid expression containing them is evaluated. For example, if `m0` is `1` and the launcher input is `m0a(2)`, `m0` will become `3`. If you type a space, `m0` will become `5` as a new valid expression is evaluated.
 
 ### Base N Calculator
 

--- a/calculate_anything/calculation/units.py
+++ b/calculate_anything/calculation/units.py
@@ -286,9 +286,7 @@ class CurrencyUnitsCalculation(UnitsCalculation):
         if unit_to_name:
             unit_to_name = unit_to_name[0]
         else:
-            unit_to_name = (
-                str(self.unit_to).replace('currency_', '', 1).replace()
-            )
+            unit_to_name = str(self.unit_to).replace('currency_', '', 1)
 
         if unit_to_name in FLAGS:
             icon = FLAGS[unit_to_name]

--- a/calculate_anything/currency/providers/base.py
+++ b/calculate_anything/currency/providers/base.py
@@ -18,6 +18,7 @@ class CurrencyProvider(ABC):
     PROTOCOL: str
     HOSTNAME: str
     API_URL: str
+    REQUEST_TIMEOUT = 5
 
     class Decorators:
         @staticmethod

--- a/calculate_anything/currency/providers/coinbase.py
+++ b/calculate_anything/currency/providers/coinbase.py
@@ -93,7 +93,7 @@ class CoinbaseCurrencyProvider(FreeCurrencyProvider):
         try:
             request = self.get_request(params)
             logger.info('Making request to: {}'.format(request.full_url))
-            with urlopen(request) as response:  # nosec
+            with urlopen(request, timeout=self.REQUEST_TIMEOUT) as response:  # nosec
                 data = response.read().decode()
                 response_code = response.getcode()
         except HTTPError as e:

--- a/calculate_anything/currency/providers/european_central_bank.py
+++ b/calculate_anything/currency/providers/european_central_bank.py
@@ -90,7 +90,7 @@ class ECBCurrencyProvider(FreeCurrencyProvider):
         try:
             request = self.get_request()
             logger.info('Making request to: {}'.format(request.full_url))
-            with urlopen(request) as response:  # nosec
+            with urlopen(request, timeout=self.REQUEST_TIMEOUT) as response:  # nosec
                 data = response.read().decode()
                 response_code = response.getcode()
         except HTTPError as e:

--- a/calculate_anything/currency/providers/fixerio.py
+++ b/calculate_anything/currency/providers/fixerio.py
@@ -95,7 +95,7 @@ class FixerIOCurrencyProvider(ApiKeyCurrencyProvider):
         try:
             request = self.get_request(params)
             logger.info('Making request to: {}'.format(request.full_url))
-            with urlopen(request) as response:  # nosec
+            with urlopen(request, timeout=self.REQUEST_TIMEOUT) as response:  # nosec
                 data = response.read().decode()
                 response_code = response.getcode()
         except HTTPError as e:

--- a/calculate_anything/currency/providers/mycurrencynet.py
+++ b/calculate_anything/currency/providers/mycurrencynet.py
@@ -78,7 +78,7 @@ class MyCurrencyNetCurrencyProvider(FreeCurrencyProvider):
         try:
             request = self.get_request()
             logger.info('Making request to: {}'.format(request.full_url))
-            with urlopen(request) as response:  # nosec
+            with urlopen(request, timeout=self.REQUEST_TIMEOUT) as response:  # nosec
                 data = response.read().decode()
                 response_code = response.getcode()
         except HTTPError as e:

--- a/calculate_anything/currency/service.py
+++ b/calculate_anything/currency/service.py
@@ -66,22 +66,27 @@ class UpdateThread(Thread):
         self.wake()
 
     def _get_currencies(self, *currencies: str, force: bool) -> CurrencyData:
-        if force:
-            pass
-        elif self._cache.enabled and not self._cache.should_update():
-            return self._cache.get_rates(*currencies)
+        if not force:
+            with self.lock:
+                cache_enabled = self._cache.enabled
+                should_update = (
+                    self._cache.should_update() if cache_enabled else False
+                )
+                if cache_enabled and not should_update:
+                    return self._cache.get_rates(*currencies)
 
         self._logger.info('Will load currencies')
-        self._cache.clear()
-        currency_rates = self._provider.request_currencies(
-            *currencies, force=force
-        )
+        with self.lock:
+            self._cache.clear()
+            provider = self._provider
+            cache = self._cache
+        currency_rates = provider.request_currencies(*currencies, force=force)
         if not self._stopped_event.is_set():
-            provider_name = self._provider.__class__.__name__
-            self._cache.save(currency_rates, provider_name)
+            with self.lock:
+                provider_name = provider.__class__.__name__
+                cache.save(currency_rates, provider_name)
         return currency_rates
 
-    @with_lock
     def _run(self, force: bool) -> float:
         next_update = 60.0
 
@@ -91,11 +96,15 @@ class UpdateThread(Thread):
         except Exception as e:
             self._logger.exception('Could not get currencies: {}'.format(e))
 
-        with safe_operation():
-            self._callback(currency_rates, self._provider.had_error)
+        with self.lock:
+            had_error = self._provider.had_error
 
-        if not self._provider.had_error:
-            cache_next_update = self._cache.next_update_seconds()
+        with safe_operation():
+            self._callback(currency_rates, had_error)
+
+        if not had_error:
+            with self.lock:
+                cache_next_update = self._cache.next_update_seconds()
             next_update = max(next_update, cache_next_update)
         return next_update
 

--- a/calculate_anything/preferences.py
+++ b/calculate_anything/preferences.py
@@ -319,6 +319,14 @@ class UnitsPreferences(_Preferences):
             UnitsService().start()
 
 
+class CalculatorPreferences(_Preferences):
+    '''The calculator preferences class
+
+    Attributes:
+    TODO
+    '''
+
+
 class Preferences(metaclass=Singleton):
     '''The Preferences class is a Singleton class which holds all other
     preferences, like language, timezone, units and currency.
@@ -335,6 +343,7 @@ class Preferences(metaclass=Singleton):
         self.time = TimePreferences()
         self.units = UnitsPreferences()
         self.currency = CurrencyPreferences()
+        self.calculator = CalculatorPreferences()
 
     def commit(self) -> None:
         '''Commits preference changes in proper order'''
@@ -342,3 +351,4 @@ class Preferences(metaclass=Singleton):
         self.time.commit()
         self.units.commit()
         self.currency.commit()
+        self.calculator.commit()

--- a/calculate_anything/preferences.py
+++ b/calculate_anything/preferences.py
@@ -8,6 +8,7 @@ from calculate_anything.currency.providers.base import CurrencyProvider
 from calculate_anything.currency import CurrencyService
 from calculate_anything.lang import LanguageService
 from calculate_anything.time import TimezoneService
+from calculate_anything.query.handlers.calculator import CalculatorQueryHandler
 from calculate_anything.utils import (
     Singleton,
     get_or_default,
@@ -323,8 +324,28 @@ class CalculatorPreferences(_Preferences):
     '''The calculator preferences class
 
     Attributes:
-    TODO
+        None
     '''
+
+    def set_trig_mode(self, trig_mode: str) -> None:
+        '''The trigonometry mode to be set. The mode is not set immediately,
+        but only after 'commit()' is called
+
+        Args:
+            trig_mode (str): The trigonometry mode to set. It must be one of
+                'deg', 'rad', or 'grad'.
+        '''
+        trig_mode = get_or_default(
+            trig_mode,
+            str,
+            'rad',
+            ['deg', 'rad', 'grad'],
+        ).lower()
+        super()._to_commit('trig_mode', trig_mode)
+
+    def _commit_one(self, key: str, value: Any) -> None:
+        if key == 'trig_mode':
+            CalculatorQueryHandler.trig_mode = value
 
 
 class Preferences(metaclass=Singleton):

--- a/calculate_anything/query/handlers/calculator.py
+++ b/calculate_anything/query/handlers/calculator.py
@@ -64,9 +64,15 @@ class CalculatorQueryHandler(QueryHandler, metaclass=Singleton):
             memory = CalculatorQueryHandler.memory
             if len(args) == num_args:
                 memory[index] = fn(*((memory[index],) + args))
-            return memory[index]
+                return memory[index]
+            return None
 
         return load
+
+    @staticmethod
+    def mem_clear():
+        CalculatorQueryHandler.memory = [0] * 10
+        return 0
 
     def convert_args(name, args, conversion):
         if any(arg.imag != 0 for arg in args):
@@ -117,8 +123,13 @@ class CalculatorQueryHandler(QueryHandler, metaclass=Singleton):
                     "m{}s".format(i): self.mem_load(i, op.sub),
                     "m{}m".format(i): self.mem_load(i, op.mul),
                     "m{}d".format(i): self.mem_load(i, op.truediv),
+                    "m{}e".format(i): self.mem_load(i, op.pow),
+                    "m{}r".format(i): self.mem_load(
+                        i, lambda x, y: op.pow(x, 1 / y)
+                    ),
                 }
             )
+        functions.update(mc=self.mem_clear)
 
         math_fns = {
             name: getattr(cmath, name)

--- a/calculate_anything/query/handlers/units.py
+++ b/calculate_anything/query/handlers/units.py
@@ -42,12 +42,16 @@ class UnitsQueryHandler(QueryHandler, metaclass=Singleton):
         self, units: Iterable['pint.Unit']
     ) -> List[CalculationError]:
         dimensionalities = set(unit.dimensionality for unit in units)
+        has_currency = any(
+            map(lambda d: '[currency]' in d, dimensionalities)
+        )
+        if not has_currency:
+            return []
         currency_service = CurrencyService()
 
         currency_provider_had_error = (
             currency_service.enabled
             and currency_service.provider_had_error
-            and any(map(lambda d: '[currency]' in d, dimensionalities))
         )
         if currency_provider_had_error:
             item = CalculationError(CurrencyProviderException())

--- a/main.py
+++ b/main.py
@@ -157,6 +157,10 @@ class PreferencesEventListener(EventListener):
             default_currencies = event.preferences['default_currencies']
             preferences.currency.set_default_currencies(default_currencies)
 
+        with safe_operation('Set trigonometry mode'):
+            trig_mode = event.preferences['trig_mode']
+            preferences.calculator.set_trigonometry_mode(trig_mode)
+
         preferences.commit()
 
 
@@ -187,6 +191,8 @@ class PreferencesUpdateEventListener(EventListener):
             preferences.time.set_default_cities(event.new_value)
         elif event.id == 'units_conversion_mode':
             preferences.units.set_conversion_mode(event.new_value)
+        elif event.id == 'trigonometry_mode':
+            preferences.calculator.set_trigonometry_mode(event.new_value)
 
         preferences.commit()
 

--- a/main.py
+++ b/main.py
@@ -52,8 +52,7 @@ class CalculateAnythingExtension(Extension):
 class KeywordQueryEventListener(EventListener):
     def on_event(self, event, extension):
         query_nokw = event.get_argument() or ''
-        query = event.get_query() or ''
-        query = query.replace(event.get_keyword() + ' ', '', 1)
+        query = query_nokw
         mode = 'calculator'
         if event.get_keyword() == extension.preferences['time_kw']:
             query = TimeQueryHandler().keyword + query

--- a/main.py
+++ b/main.py
@@ -159,7 +159,7 @@ class PreferencesEventListener(EventListener):
 
         with safe_operation('Set trigonometry mode'):
             trig_mode = event.preferences['trig_mode']
-            preferences.calculator.set_trigonometry_mode(trig_mode)
+            preferences.calculator.set_trig_mode(trig_mode)
 
         preferences.commit()
 
@@ -191,8 +191,8 @@ class PreferencesUpdateEventListener(EventListener):
             preferences.time.set_default_cities(event.new_value)
         elif event.id == 'units_conversion_mode':
             preferences.units.set_conversion_mode(event.new_value)
-        elif event.id == 'trigonometry_mode':
-            preferences.calculator.set_trigonometry_mode(event.new_value)
+        elif event.id == 'trig_mode':
+            preferences.calculator.set_trig_mode(event.new_value)
 
         preferences.commit()
 

--- a/manifest.json
+++ b/manifest.json
@@ -51,6 +51,18 @@
       "default_value": "bin"
     },
     {
+      "id": "trig_mode",
+      "type": "select",
+      "name": "Trigonometry Mode",
+      "description": "The unit used for trigonometric calculations",
+      "default_value": "rad",
+      "options": [
+        {"value": "deg", "text": "Degree"},
+        {"value": "rad", "text": "Radian"},
+        {"value": "grad", "text": "Gradian"}
+      ]
+    },
+    {
       "id": "currency_provider",
       "type": "select",
       "name": "Currency Provider",


### PR DESCRIPTION
## Summary

Combines three independent improvements:

- **Ulauncher v6 fix**: `event.get_query()` returns a `Query` object in v6, not a string. Use `event.get_argument()` directly instead
- **Deadlock fix** (from PR #67 by @nnqnn): fine-grained locking in currency service prevents query handler blocking on network requests, plus timeouts on all `urlopen()` calls
- **Calculator features** (from @CyrilSLi's fork): trig unit conversion (deg/rad/grad), reciprocal trig functions (csc, sec, cot), persistent memory variables (m0-m9), `ans()` function

## Test plan

- Tested on Ulauncher v6.0.0-beta29
- Calculator queries (`= 5+3`, `= sin(pi/2)`) return results without crashing
- Currency queries no longer hang on "Loading..."